### PR TITLE
Fix compatibility issues with Spring Boot 2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+2.0.4.RELEASE / 2018-08-14
+==================
+
+  * upgraded to SpringBoot 2.0.4.RELEASE
+  * fixed compatibility issues with SpringBoot 2
+  * setting version to 2.0.4.RELEASE
 
 0.3.1 / 2015-09-09
 ==================

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= Spring Boot jade4j Starter
+= jade4j Spring Boot Starter
 
 // image:https://dl.dropboxusercontent.com/u/3942208/spring-jade-100x100.png[Logo]
 
@@ -9,38 +9,38 @@ image:https://badges.gitter.im/Join%20Chat.svg["Gitter", link="https://gitter.im
 
 ---
 
-This Starter provides you the minimal and required configuration to use http://jade-lang.com/[jade templates] as views in your Spring Boot application.
+This Starter provides you the minimal and required configuration to use https://pugjs.org[pug/jade templates] as views in your Spring Boot application.
 
 Behind the scenes, this starter uses the https://github.com/neuland/jade4j[jade4j] and https://github.com/neuland/spring-jade4j[spring-jade4j] libraries.
 
 == Environment
 
-image:https://img.shields.io/badge/JDK-7.0+-F30000.svg?style=flat["JDK", link="http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"]
-image:https://img.shields.io/badge/Spring%20Framework-4.2.x-green.svg?style=flat&["Spring Framework", link="http://docs.spring.io/spring/docs/4.2.x/spring-framework-reference/htmlsingle/"]
-image:https://img.shields.io/badge/Spring%20Boot-1.3.0.M5-green.svg?style=flat&["Spring Boot", link="http://docs.spring.io/spring-boot/docs/1.3.0.M5/reference/htmlsingle/"]
+image:https://img.shields.io/badge/JDK-8.0+-F30000.svg?style=flat["JDK", link="http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"]
+image:https://img.shields.io/badge/Spring%20Framework-5.0.x-green.svg?style=flat&["Spring Framework", link="https://docs.spring.io/spring/docs/5.0.x/spring-framework-reference/"]
+image:https://img.shields.io/badge/Spring%20Boot-2.0.x-green.svg?style=flat&["Spring Boot", link="https://docs.spring.io/spring-boot/docs/2.0.x/reference/htmlsingle/"]
 
 == Download
 
 Maven Central
-image:https://maven-badges.herokuapp.com/maven-central/com.domingosuarez.boot/spring-boot-starter-jade4j/badge.svg?style=flat["Download",link="https://maven-badges.herokuapp.com/maven-central/com.domingosuarez.boot/spring-boot-starter-jade4j"]
+image:https://maven-badges.herokuapp.com/maven-central/com.domingosuarez.boot/jade4j-spring-boot-starter/badge.svg?style=flat["Download",link="https://maven-badges.herokuapp.com/maven-central/com.domingosuarez.boot/jade4j-spring-boot-starter"]
 
 JCenter
-image:https://api.bintray.com/packages/domix/spring-boot/spring-boot-starter-jade4j/images/download.svg["Download", link="https://bintray.com/domix/spring-boot/spring-boot-starter-jade4j/_latestVersion"]
+image:https://api.bintray.com/packages/domix/spring-boot/jade4j-spring-boot-starter/images/download.svg["Download", link="https://bintray.com/domix/spring-boot/jade4j-spring-boot-starter/_latestVersion"]
 
 == Issues
 
-image:https://badge.waffle.io/domix/spring-boot-starter-jade4j.svg?label=ready&title=Ready["Stories in Ready", link="http://waffle.io/domix/spring-boot-starter-jade4j"]
+image:https://badge.waffle.io/domix/jade4j-spring-boot-starter.svg?label=ready&title=Ready["Stories in Ready", link="http://waffle.io/domix/jade4j-spring-boot-starter"]
 
 
-image:https://graphs.waffle.io/domix/spring-boot-starter-jade4j/throughput.svg["Throughput Graph", link="https://waffle.io/domix/spring-boot-starter-jade4j/metrics"]
+image:https://graphs.waffle.io/domix/jade4j-spring-boot-starter/throughput.svg["Throughput Graph", link="https://waffle.io/domix/jade4j-spring-boot-starter/metrics"]
 
 
 
 == GitHub, Factoids and Stats
 
-image:https://img.shields.io/github/forks/domix/spring-boot-starter-jade4j.svg?style=flat["Forks", link="https://github.com/domix/spring-boot-starter-jade4j/network"]
-image:https://img.shields.io/github/release/domix/spring-boot-starter-jade4j.svg?style=flat["Release", link="https://github.com/domix/spring-boot-starter-jade4j/releases"]
-image:https://img.shields.io/github/issues/domix/spring-boot-starter-jade4j.svg?style=flat["Issues", link="https://github.com/domix/spring-boot-starter-jade4j/issues"]
+image:https://img.shields.io/github/forks/domix/jade4j-spring-boot-starter.svg?style=flat["Forks", link="https://github.com/domix/jade4j-spring-boot-starter/network"]
+image:https://img.shields.io/github/release/domix/jade4j-spring-boot-starter.svg?style=flat["Release", link="https://github.com/domix/jade4j-spring-boot-starter/releases"]
+image:https://img.shields.io/github/issues/domix/jade4j-spring-boot-starter.svg?style=flat["Issues", link="https://github.com/domix/jade4j-spring-boot-starter/issues"]
 
 ++++
 <script type="text/javascript" src="http://www.openhub.net/p/721264/widgets/project_basic_stats.js"></script>
@@ -59,7 +59,7 @@ The usage is pretty straightforward as you can expect for any Spring Boot Starte
 ----
 ...
 dependencies {
-  compile "com.domingosuarez.boot:spring-boot-starter-jade4j:0.3.1"
+  compile "com.domingosuarez.boot:jade4j-spring-boot-starter:2.0.4.RELEASE"
 }
 ...
 ----
@@ -73,8 +73,8 @@ dependencies {
   <dependencies>
     <dependency>
       <groupId>com.domingosuarez.boot</groupId>
-      <artifactId>spring-boot-starter-jade4j</artifactId>
-      <version>0.3.1</version>
+      <artifactId>jade4j-spring-boot-starter</artifactId>
+      <version>2.0.4.RELEASE</version>
     </dependency>
   </dependencies>
 </project>
@@ -96,7 +96,7 @@ Then you can add new Spring MVC controllers as usual
 ---
 
 == Helpers
-You can add https://github.com/neuland/jade4j#helpers[helpers] automatically using the annotation https://github.com/domix/spring-boot-starter-jade4j/blob/master/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/JadeHelper.java[@JadeHelper]
+You can add https://github.com/neuland/jade4j#helpers[helpers] automatically using the annotation https://github.com/domix/jade4j-spring-boot-starter/blob/master/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/JadeHelper.java[@JadeHelper]
 
 [source,java]
 ----
@@ -126,7 +126,7 @@ html
 
 
 === Customize the helper's name
-You can customize the helper's name using the https://github.com/domix/spring-boot-starter-jade4j/blob/master/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/JadeHelper.java[JadeHelper] annotation
+You can customize the helper's name using the https://github.com/domix/jade4j-spring-boot-starter/blob/master/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/JadeHelper.java[JadeHelper] annotation
 [source,java]
 ----
 package demo;
@@ -177,4 +177,4 @@ spring.jade4j.resolver.order, Integer, Ordered.LOWEST_PRECEDENCE - 50
 
 == Complete demo application
 
-Please take a look into this https://github.com/domix/spring-boot-starter-jade4j-showcase[application] if you want to checkout a fully application.
+Please take a look into this https://github.com/domix/jade4j-spring-boot-starter-showcase[application] if you want to checkout a fully application.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 #Mon, 08 Jun 2015 23:04:17 -0500
 group=com.domingosuarez.boot
-version=0.3.3
+version=2.0.4.RELEASE
 
 description=This Starter provides you the minimal and required configuration to use jade templates as views in your Spring Boot application.
 pomName=jade4j Spring Boot Starter
 
-javaVersion=1.7
-springBootVersion=1.5.10.RELEASE
+javaVersion=1.8
+springBootVersion=2.0.4.RELEASE

--- a/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/Jade4JAutoConfiguration.java
+++ b/src/main/java/com/domingosuarez/boot/autoconfigure/jade4j/Jade4JAutoConfiguration.java
@@ -27,8 +27,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
-import org.springframework.boot.bind.RelaxedPropertyResolver;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,18 +63,18 @@ public class Jade4JAutoConfiguration {
     @Autowired
     private final ResourceLoader resourceLoader = new DefaultResourceLoader();
 
-    private RelaxedPropertyResolver environment;
+    private Environment environment;
 
     @Override
     public void setEnvironment(Environment environment) {
-      this.environment = new RelaxedPropertyResolver(environment, "spring.jade4j.");
+      this.environment = environment;
     }
 
     @PostConstruct
     public void checkTemplateLocationExists() {
-      Boolean checkTemplateLocation = this.environment.getProperty("checkTemplateLocation", Boolean.class, true);
+      Boolean checkTemplateLocation = this.environment.getProperty("spring.jade4j.checkTemplateLocation", Boolean.class, true);
       if (checkTemplateLocation) {
-        Resource resource = this.resourceLoader.getResource(this.environment.getProperty("prefix", DEFAULT_PREFIX));
+        Resource resource = this.resourceLoader.getResource(this.environment.getProperty("spring.jade4j.prefix", DEFAULT_PREFIX));
         Assert.state(resource.exists(), "Cannot find template location: "
           + resource + " (please add some templates or check your jade4j configuration)");
       }
@@ -85,19 +84,19 @@ public class Jade4JAutoConfiguration {
     public SpringTemplateLoader defaultSpringTemplateLoader() {
       SpringTemplateLoader resolver = new SpringTemplateLoader();
 
-      resolver.setBasePath(this.environment.getProperty("prefix", DEFAULT_PREFIX));
-      resolver.setSuffix(this.environment.getProperty("suffix", DEFAULT_SUFFIX));
-      resolver.setEncoding(this.environment.getProperty("encoding", "UTF-8"));
+      resolver.setBasePath(this.environment.getProperty("spring.jade4j.prefix", DEFAULT_PREFIX));
+      resolver.setSuffix(this.environment.getProperty("spring.jade4j.suffix", DEFAULT_SUFFIX));
+      resolver.setEncoding(this.environment.getProperty("spring.jade4j.encoding", "UTF-8"));
       return resolver;
     }
 
     @Bean
     public JadeConfiguration defaultJadeConfiguration() {
       JadeConfiguration configuration = new JadeConfiguration();
-      configuration.setCaching(this.environment.getProperty("caching", Boolean.class, true));
+      configuration.setCaching(this.environment.getProperty("spring.jade4j.caching", Boolean.class, true));
       configuration.setTemplateLoader(defaultSpringTemplateLoader());
-      configuration.setPrettyPrint(this.environment.getProperty("prettyPrint", Boolean.class, false));
-      configuration.setMode(this.environment.getProperty("mode", Jade4J.Mode.class, Jade4J.Mode.HTML));
+      configuration.setPrettyPrint(this.environment.getProperty("spring.jade4j.prettyPrint", Boolean.class, false));
+      configuration.setMode(this.environment.getProperty("spring.jade4j.mode", Jade4J.Mode.class, Jade4J.Mode.HTML));
       return configuration;
     }
 
@@ -109,7 +108,7 @@ public class Jade4JAutoConfiguration {
   @ConditionalOnWebApplication
   protected static class Jade4JViewResolverConfiguration implements EnvironmentAware {
 
-    private RelaxedPropertyResolver environment;
+    private Environment environment;
 
     @Autowired
     private JadeConfiguration jadeConfiguration;
@@ -119,7 +118,7 @@ public class Jade4JAutoConfiguration {
 
     @Override
     public void setEnvironment(Environment environment) {
-      this.environment = new RelaxedPropertyResolver(environment, "spring.jade4j.");
+      this.environment = environment;
     }
 
     @Bean
@@ -129,13 +128,13 @@ public class Jade4JAutoConfiguration {
       resolver.setConfiguration(jadeConfiguration);
 
       resolver.setContentType(appendCharset(
-        this.environment.getProperty("contentType", "text/html"),
+        this.environment.getProperty("spring.jade4j.contentType", "text/html"),
         templateEngine.getEncoding()));
 
-      resolver.setViewNames(this.environment.getProperty("viewNames", String[].class));
+      resolver.setViewNames(this.environment.getProperty("spring.jade4j.viewNames", String[].class));
       // This resolver acts as a fallback resolver (e.g. like a
       // InternalResourceViewResolver) so it needs to have low precedence
-      resolver.setOrder(this.environment.getProperty("resolver.order", Integer.class, Ordered.LOWEST_PRECEDENCE - 50));
+      resolver.setOrder(this.environment.getProperty("spring.jade4j.resolver.order", Integer.class, Ordered.LOWEST_PRECEDENCE - 50));
       return resolver;
     }
 

--- a/src/test/java/com/domingosuarez/boot/autoconfigure/jade4j/Jade4JAutoConfigurationTests.java
+++ b/src/test/java/com/domingosuarez/boot/autoconfigure/jade4j/Jade4JAutoConfigurationTests.java
@@ -26,7 +26,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -63,7 +63,7 @@ public class Jade4JAutoConfigurationTests {
 
   @Test
   public void shouldRenderTemplateAsExpected() throws Exception {
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.mode:XHTML");
+    TestPropertyValues.of("spring.jade4j.mode:XHTML").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
     this.context.refresh();
     JadeConfiguration engine = this.context.getBean(JadeConfiguration.class);
@@ -77,7 +77,7 @@ public class Jade4JAutoConfigurationTests {
 
   @Test
   public void shouldRenderTemplateWithParams() throws Exception {
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.mode:XHTML");
+    TestPropertyValues.of("spring.jade4j.mode:XHTML").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
     this.context.refresh();
     JadeConfiguration engine = this.context.getBean(JadeConfiguration.class);
@@ -90,7 +90,7 @@ public class Jade4JAutoConfigurationTests {
 
   @Test
   public void shouldRenderPrettyTemplateTemplate() throws Exception {
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.prettyPrint:true");
+    TestPropertyValues.of("spring.jade4j.prettyPrint:true").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
     this.context.refresh();
     JadeConfiguration engine = this.context.getBean(JadeConfiguration.class);
@@ -111,7 +111,7 @@ public class Jade4JAutoConfigurationTests {
 
   @Test(expected = BeanCreationException.class)
   public void templateLocationDoesNotExist() throws Exception {
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.prefix:classpath:/no-such-directory/");
+    TestPropertyValues.of("spring.jade4j.prefix:classpath:/no-such-directory/").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
     this.context.refresh();
   }
@@ -120,7 +120,7 @@ public class Jade4JAutoConfigurationTests {
   @Ignore
   public void templateLocationEmpty() throws Exception {
     new File("./build/classes/test/templates/empty-directory").mkdir();
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.prefix:classpath:/templates/empty-directory/");
+    TestPropertyValues.of("spring.jade4j.prefix:classpath:/templates/empty-directory/").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class);
     this.context.refresh();
   }
@@ -147,7 +147,7 @@ public class Jade4JAutoConfigurationTests {
 
   @Test
   public void createLayoutFromConfigClass_withHelper() throws Exception {
-    EnvironmentTestUtils.addEnvironment(this.context, "spring.jade4j.mode:XHTML");
+    TestPropertyValues.of("spring.jade4j.mode:XHTML").applyTo(context);
     this.context.register(Jade4JAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class, TestConfig.class);
     this.context.refresh();
     JadeConfiguration engine = this.context.getBean(JadeConfiguration.class);


### PR DESCRIPTION
Closes #14 

- `RelaxedPropertyResolver` was removed from Spring Boot 2 so I changed `Jade4JAutoConfiguration` to use `Environment` directly

- `EnvironmentTestUtils` has been deprecated, so I've replaced it with `TestPropertyValues` in `Jade4JAutoConfigurationTests`

- The package version has been updated to `2.0.4.RELEASE`

- Updated README and History.md